### PR TITLE
Update APIs

### DIFF
--- a/build/panorama/enums/index.ts
+++ b/build/panorama/enums/index.ts
@@ -10,7 +10,7 @@ export const enums = (() => {
     .map(
       (group): Enum => {
         const enumName = group.match(/Enumeration '(.+?)'/)![1];
-        const members = [...group.matchAll(/^\t.+\.(.+?) = (\d+)(?: \((.+)\))?$/gm)].map(
+        const members = [...group.matchAll(/^\t.+\.(.+?) = (-?\d+)(?: \((.+)\))?$/gm)].map(
           ([, name, value, description]): EnumMember => ({
             name,
             description,

--- a/build/vscripts/api-types/index.ts
+++ b/build/vscripts/api-types/index.ts
@@ -466,6 +466,38 @@ apiTypesDeclarations.push({
   ],
 });
 
+apiTypesDeclarations.push({
+  kind: 'object',
+  name: 'SpawnEntityFromTableOptions',
+  fields: [
+    { name: 'origin', types: ['string', 'Vector', 'nil'] },
+    { name: 'angles', types: ['string', 'QAngle', 'nil'] },
+    { name: 'scales', types: ['string', 'Vector', 'nil'] },
+    { name: 'targetname', types: ['string', 'nil'] },
+    { name: 'vscripts', types: ['string', 'nil'] },
+  ],
+});
+
+apiTypesDeclarations.push({
+  kind: 'object',
+  name: 'CreateUnitFromTableOptions',
+  extend: ['SpawnEntityFromTableOptions'],
+  fields: [
+    { name: 'MapUnitName', types: ['string'] },
+    { name: 'teamnumber', types: ['DOTATeam_t', 'nil'] },
+    { name: 'modelscale', types: ['number', 'nil'] },
+    {
+      name: 'initial_waypoint',
+      types: ['string', 'nil'],
+      description: 'targetname of path_corner or path_track',
+    },
+    { name: 'EnableAutoStyles', types: ['string', 'nil'] },
+    { name: 'rendercolor', types: ['string', 'nil'], description: 'RGB, example: "255 255 255"' },
+    { name: 'skin', types: ['number', 'nil'] },
+    { name: 'NeverMoveToClearSpace', types: ['boolean', 'nil'] },
+  ],
+});
+
 export function validateApiTypes() {
   for (const declaration of apiTypesDeclarations) {
     switch (declaration.kind) {

--- a/build/vscripts/api-types/index.ts
+++ b/build/vscripts/api-types/index.ts
@@ -485,7 +485,7 @@ apiTypesDeclarations.push({
   fields: [
     { name: 'MapUnitName', types: ['string'] },
     { name: 'teamnumber', types: ['DOTATeam_t', 'nil'] },
-    { name: 'modelscale', types: ['number', 'nil'] },
+    { name: 'modelscale', types: ['int', 'nil'] },
     {
       name: 'initial_waypoint',
       types: ['string', 'nil'],
@@ -493,8 +493,8 @@ apiTypesDeclarations.push({
     },
     { name: 'EnableAutoStyles', types: ['string', 'nil'] },
     { name: 'rendercolor', types: ['string', 'nil'], description: 'RGB, example: "255 255 255"' },
-    { name: 'skin', types: ['number', 'nil'] },
-    { name: 'NeverMoveToClearSpace', types: ['boolean', 'nil'] },
+    { name: 'skin', types: ['int', 'nil'] },
+    { name: 'NeverMoveToClearSpace', types: ['bool', 'nil'] },
   ],
 });
 

--- a/build/vscripts/api/data/index.ts
+++ b/build/vscripts/api/data/index.ts
@@ -741,7 +741,7 @@ export const functionExtensions: Record<string, ExtensionFunction> = {
       '3': [null, ['table', 'nil']],
       '5': [null, 'DOTATeam_t'],
     },
-    returns: 'CDOTA_BaseNPC'
+    returns: 'CDOTA_BaseNPC',
   },
   '_G.CreateUniformRandomStream': { returns: 'CScriptUniformRandomStream' },
   '_G.ExecuteOrderFromTable': { args: { 0: ['order', 'ExecuteOrderOptions'] } },

--- a/build/vscripts/api/data/index.ts
+++ b/build/vscripts/api/data/index.ts
@@ -741,6 +741,7 @@ export const functionExtensions: Record<string, ExtensionFunction> = {
       '3': [null, ['table', 'nil']],
       '5': [null, 'DOTATeam_t'],
     },
+    returns: 'CDOTA_BaseNPC'
   },
   '_G.CreateUniformRandomStream': { returns: 'CScriptUniformRandomStream' },
   '_G.ExecuteOrderFromTable': { args: { 0: ['order', 'ExecuteOrderOptions'] } },

--- a/build/vscripts/api/data/moddota-dump.ts
+++ b/build/vscripts/api/data/moddota-dump.ts
@@ -476,7 +476,7 @@ export const moddotaDump: Record<string, ExtensionFunction> = {
     args: {
       '0': ['particleName'],
       '1': ['particleAttach', 'ParticleAttachment_t'],
-      '2': ['owner', ['CDOTA_BaseNPC', 'nil']],
+      '2': ['owner', ['CBaseEntity', 'nil']],
     },
   },
   'CScriptParticleManager.CreateParticleForPlayer': {
@@ -484,7 +484,7 @@ export const moddotaDump: Record<string, ExtensionFunction> = {
     args: {
       '0': ['particleName'],
       '1': ['particleAttach', 'ParticleAttachment_t'],
-      '2': ['owner', ['CDOTA_BaseNPC', 'nil']],
+      '2': ['owner', ['CBaseEntity', 'nil']],
       '3': ['player', 'CDOTAPlayer'],
     },
   },
@@ -493,7 +493,7 @@ export const moddotaDump: Record<string, ExtensionFunction> = {
     args: {
       '0': ['particleName'],
       '1': ['particleAttach', 'ParticleAttachment_t'],
-      '2': ['owner', ['CDOTA_BaseNPC', 'nil']],
+      '2': ['owner', ['CBaseEntity', 'nil']],
       '3': ['team', 'DOTATeam_t'],
     },
   },
@@ -509,7 +509,7 @@ export const moddotaDump: Record<string, ExtensionFunction> = {
     args: {
       '0': ['particle', 'ParticleID'],
       '1': ['controlPoint'],
-      '2': ['unit', 'CDOTA_BaseNPC'],
+      '2': ['unit', 'CBaseEntity'],
       '3': ['particleAttach', 'ParticleAttachment_t'],
       '4': ['attachment'],
       '5': ['offset'],

--- a/build/vscripts/api/data/moddota-dump.ts
+++ b/build/vscripts/api/data/moddota-dump.ts
@@ -610,6 +610,13 @@ Warning: mass synchronous unit spawning may be slow. Prefer CreateUnitByNameAsyn
       '6': ['callback', func([['unit', 'CDOTA_BaseNPC']], 'nil')],
     },
   },
+  '_G.CreateUnitFromTable': {
+    args: {
+      '0': ['options', ['CreateUnitFromTableOptions']],
+      '1': ['location', ['Vector']],
+    },
+    returns: 'CDOTA_BaseNPC',
+  },
   '_G.DoCleaveAttack': {
     args: {
       0: ['attacker', 'CDOTA_BaseNPC'],

--- a/files/panorama/enums.json
+++ b/files/panorama/enums.json
@@ -134,6 +134,10 @@
       {
         "name": "GameManagedItems",
         "value": 12
+      },
+      {
+        "name": "All",
+        "value": -1
       }
     ]
   },
@@ -872,6 +876,10 @@
   {
     "name": "DOTA_RUNES",
     "members": [
+      {
+        "name": "DOTA_RUNE_INVALID",
+        "value": -1
+      },
       {
         "name": "DOTA_RUNE_DOUBLEDAMAGE",
         "value": 0
@@ -2752,6 +2760,10 @@
     "name": "DOTASlotType_t",
     "members": [
       {
+        "name": "DOTA_LOADOUT_TYPE_INVALID",
+        "value": -1
+      },
+      {
         "name": "DOTA_LOADOUT_TYPE_WEAPON",
         "value": 0
       },
@@ -4577,12 +4589,20 @@
       {
         "name": "DOTA_ATTRIBUTE_MAX",
         "value": 3
+      },
+      {
+        "name": "DOTA_ATTRIBUTE_INVALID",
+        "value": -1
       }
     ]
   },
   {
     "name": "ParticleAttachment_t",
     "members": [
+      {
+        "name": "PATTACH_INVALID",
+        "value": -1
+      },
       {
         "name": "PATTACH_ABSORIGIN",
         "value": 0
@@ -4778,12 +4798,20 @@
       {
         "name": "DOTA_CUSTOM_UI_TYPE_COUNT",
         "value": 8
+      },
+      {
+        "name": "DOTA_CUSTOM_UI_TYPE_INVALID",
+        "value": -1
       }
     ]
   },
   {
     "name": "DotaDefaultUIElement_t",
     "members": [
+      {
+        "name": "DOTA_DEFAULT_UI_INVALID",
+        "value": -1
+      },
       {
         "name": "DOTA_DEFAULT_UI_TOP_TIMEOFDAY",
         "value": 0
@@ -4912,6 +4940,18 @@
       {
         "name": "PLAYER_ULTIMATE_STATE_READY",
         "value": 0
+      },
+      {
+        "name": "PLAYER_ULTIMATE_STATE_NO_MANA",
+        "value": -1
+      },
+      {
+        "name": "PLAYER_ULTIMATE_STATE_NOT_LEVELED",
+        "value": -2
+      },
+      {
+        "name": "PLAYER_ULTIMATE_STATE_HIDDEN",
+        "value": -3
       }
     ]
   },

--- a/files/vscripts/api-types.json
+++ b/files/vscripts/api-types.json
@@ -1371,5 +1371,115 @@
         ]
       }
     ]
+  },
+  {
+    "kind": "object",
+    "name": "SpawnEntityFromTableOptions",
+    "fields": [
+      {
+        "name": "origin",
+        "types": [
+          "string",
+          "Vector",
+          "nil"
+        ]
+      },
+      {
+        "name": "angles",
+        "types": [
+          "string",
+          "QAngle",
+          "nil"
+        ]
+      },
+      {
+        "name": "scales",
+        "types": [
+          "string",
+          "Vector",
+          "nil"
+        ]
+      },
+      {
+        "name": "targetname",
+        "types": [
+          "string",
+          "nil"
+        ]
+      },
+      {
+        "name": "vscripts",
+        "types": [
+          "string",
+          "nil"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "object",
+    "name": "CreateUnitFromTableOptions",
+    "extend": [
+      "SpawnEntityFromTableOptions"
+    ],
+    "fields": [
+      {
+        "name": "MapUnitName",
+        "types": [
+          "string"
+        ]
+      },
+      {
+        "name": "teamnumber",
+        "types": [
+          "DOTATeam_t",
+          "nil"
+        ]
+      },
+      {
+        "name": "modelscale",
+        "types": [
+          "int",
+          "nil"
+        ]
+      },
+      {
+        "name": "initial_waypoint",
+        "types": [
+          "string",
+          "nil"
+        ],
+        "description": "targetname of path_corner or path_track"
+      },
+      {
+        "name": "EnableAutoStyles",
+        "types": [
+          "string",
+          "nil"
+        ]
+      },
+      {
+        "name": "rendercolor",
+        "types": [
+          "string",
+          "nil"
+        ],
+        "description": "RGB, example: \"255 255 255\""
+      },
+      {
+        "name": "skin",
+        "types": [
+          "int",
+          "nil"
+        ]
+      },
+      {
+        "name": "NeverMoveToClearSpace",
+        "types": [
+          "bool",
+          "nil"
+        ]
+      }
+    ]
   }
 ]

--- a/files/vscripts/api.json
+++ b/files/vscripts/api.json
@@ -29989,7 +29989,7 @@
           {
             "name": "owner",
             "types": [
-              "CDOTA_BaseNPC",
+              "CBaseEntity",
               "nil"
             ]
           }
@@ -30019,7 +30019,7 @@
           {
             "name": "owner",
             "types": [
-              "CDOTA_BaseNPC",
+              "CBaseEntity",
               "nil"
             ]
           },
@@ -30055,7 +30055,7 @@
           {
             "name": "owner",
             "types": [
-              "CDOTA_BaseNPC",
+              "CBaseEntity",
               "nil"
             ]
           },
@@ -30198,7 +30198,7 @@
           {
             "name": "unit",
             "types": [
-              "CDOTA_BaseNPC"
+              "CBaseEntity"
             ]
           },
           {
@@ -32738,7 +32738,7 @@
     "available": "server",
     "description": "Create a modifier not associated with an NPC.",
     "returns": [
-      "handle"
+      "CDOTA_BaseNPC"
     ],
     "args": [
       {
@@ -33074,17 +33074,17 @@
     "available": "server",
     "description": "Creates a DOTA unit by its dota_npc_units.txt name from a table of entity key values and a position to spawn at.",
     "returns": [
-      "handle"
+      "CDOTA_BaseNPC"
     ],
     "args": [
       {
-        "name": "arg1",
+        "name": "options",
         "types": [
-          "handle"
+          "CreateUnitFromTableOptions"
         ]
       },
       {
-        "name": "arg2",
+        "name": "location",
         "types": [
           "Vector"
         ]


### PR DESCRIPTION
- CreateModifierThinker() return CDOTA_BaseNPC
- Change CreateParticle owner type to CBaseEntity, https://github.com/ModDota/TypeScriptDeclarations/issues/9
- Create type `CreateUnitFromTableOptions` support the first argument in CreateUnitFromTable()
- Fix can't match negative number bug on dump panorama enums https://github.com/ModDota/TypeScriptDeclarations/issues/12