### PR TITLE
report_max for ModifierAttackEvent

### DIFF
--- a/build/vscripts/api-types/index.ts
+++ b/build/vscripts/api-types/index.ts
@@ -445,6 +445,7 @@ apiTypesDeclarations.push({
     { name: 'no_attack_cooldown', types: ['bool'] },
     { name: 'record', types: ['int'] }, // TODO: Add attack record type?
     { name: 'fail_type', types: ['attackfail'] },
+    { name: 'report_max', types: ['bool', 'nil'] },
   ],
 });
 

--- a/files/vscripts/api-types.json
+++ b/files/vscripts/api-types.json
@@ -1336,6 +1336,13 @@
         "types": [
           "attackfail"
         ]
+      },
+      {
+        "name": "report_max",
+        "types": [
+          "bool",
+          "nil"
+        ]
       }
     ]
   },


### PR DESCRIPTION
Adds `report_max` property to `ModifierAttackEvent`.
Used for client-side shield (barrier) display. [Discord thread](https://discord.com/channels/250160069549883392/1157325009048571904)